### PR TITLE
Fix some protocol incompatibilities

### DIFF
--- a/src/option_reply.rs
+++ b/src/option_reply.rs
@@ -132,7 +132,11 @@ impl OptionReply {
     pub(crate) fn get_data(&self) -> Vec<u8> {
         match self {
             OptionReply::Ack => vec![],
-            OptionReply::Server(name) => name.as_bytes().to_vec(),
+            OptionReply::Server(name) => {
+                let mut data = (name.len() as u32).to_be_bytes().to_vec();
+                data.extend_from_slice(name.as_bytes());
+                data
+            }
             OptionReply::Info(payload) => payload.to_vec(),
             OptionReply::MetaContext(id, name) => {
                 let mut data = id.to_be_bytes().to_vec();
@@ -221,7 +225,12 @@ mod tests {
     fn test_option_reply_get_data_server() {
         let export_name = "test_export";
         let data = OptionReply::Server(export_name.to_string()).get_data();
-        assert_eq!(data, export_name.as_bytes());
+        assert_eq!(
+            data,
+            [
+                0, 0, 0, 11, b't', b'e', b's', b't', b'_', b'e', b'x', b'p', b'o', b'r', b't'
+            ]
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -637,6 +637,7 @@ where
                 for device in self.list_devices().await? {
                     responses.push(OptionReply::Server(device));
                 }
+                responses.push(OptionReply::Ack);
             }
             OptionRequest::StartTLS => unimplemented!(),
             OptionRequest::Info(name, _info_requests) | OptionRequest::Go(name, _info_requests) => {


### PR DESCRIPTION
Using tokio-nbd with `nbd-client` (`v3.26.1`) as client behaves weirdly.
tokio-bnd does not seem to implement the network protocol correctly.

I was able to find and fix multiple issues:
- The `name_length`-field in the INFO and GO packets is a 32bit big endian integer, not an u8.
- The `list` command (to list exports) should be terminated by an ACK packet
- The `list` command (to list exports) should be of format `<u32:length><char[]:export_name>`

Is there something I'm missing? Are there multiple versions of the NBD protocol?